### PR TITLE
fail hard approach

### DIFF
--- a/4k.c
+++ b/4k.c
@@ -540,7 +540,7 @@ static i32 search(Position *pos, i32 depth, i32 alpha, i32 beta,
 
   Move moves[256];
   i32 num_moves = movegen(pos, moves, false);
-  i32 best_score = -inf;
+
   i32 moves_evaluated = 0;
   for (i32 move_index = 0; move_index < num_moves; move_index++) {
     Position npos;
@@ -552,18 +552,17 @@ static i32 search(Position *pos, i32 depth, i32 alpha, i32 beta,
 
     Move child_best_move;
     i32 score = -search(&npos, depth - 1, -beta, -alpha, &child_best_move);
-    if (score > best_score) {
-      best_score = score;
-      memcpy(best_move, &moves[move_index], sizeof(Move));
+      
 
       if (score > alpha) {
+        memcpy(best_move, &moves[move_index], sizeof(Move));
         alpha = score;
 
         if (score >= beta) {
-          break;
+          return beta;
         }
       }
-    }
+
   }
 
   if (moves_evaluated == 0) {
@@ -574,7 +573,7 @@ static i32 search(Position *pos, i32 depth, i32 alpha, i32 beta,
     }
   }
 
-  return best_score;
+  return alpha;
 }
 
 static void iteratively_deepen(Position *pos, size_t total_time) {


### PR DESCRIPTION
Use fail hard approach to save a bit of space.
Passed simplification [-10; 0] on Pohl book (5+0.05)

Score of 4k_d vs 4k_m: 799 - 754 - 555  [0.511] 2108
...      4k_d playing White: 780 - 14 - 261  [0.863] 1055
...      4k_d playing Black: 19 - 740 - 294  [0.158] 1053
...      White vs Black: 1520 - 33 - 555  [0.853] 2108
Elo difference: 7.4 +/- 12.7, LOS: 87.3 %, DrawRatio: 26.3 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
