### PR TITLE
MVV move ordering

### DIFF
--- a/4k.c
+++ b/4k.c
@@ -26,10 +26,10 @@
 #define false 0
 #define true 1
 
-enum [[nodiscard]] {
-  stdin = 0,
-  stdout = 1,
-  stderr = 2,
+enum [[nodiscard]]{
+    stdin = 0,
+    stdout = 1,
+    stderr = 2,
 };
 
 ssize_t _sys(ssize_t call, ssize_t arg1, ssize_t arg2, ssize_t arg3) {
@@ -180,7 +180,7 @@ typedef struct [[nodiscard]] {
   ssize_t tv_nsec; // nanoseconds
 } timespec;
 
-enum [[nodiscard]] { Pawn, Knight, Bishop, Rook, Queen, King, None };
+enum [[nodiscard]]{Pawn, Knight, Bishop, Rook, Queen, King, None};
 
 typedef struct [[nodiscard]] __attribute__((aligned(8))) {
   u8 from;
@@ -494,8 +494,8 @@ static void generate_piece_moves(Move *const movelist, i32 *num_moves,
   return nodes;
 }
 
-__attribute__((aligned(8))) static const i16 material[] = {127, 373,  406,
-                                                           633, 1220, 0, 0};
+__attribute__((aligned(8))) static const i16 material[] = {127,  373, 406, 633,
+                                                           1220, 0,   0};
 __attribute__((aligned(8))) static const i8 pst_rank[] = {
     0,   -7,  -8,  -8, -1, 24, 79, 0,   // Pawn
     -20, -11, -1,  8,  16, 18, 5,  -16, // Knight

--- a/4k.c
+++ b/4k.c
@@ -495,7 +495,7 @@ static void generate_piece_moves(Move *const movelist, i32 *num_moves,
 }
 
 __attribute__((aligned(8))) static const i16 material[] = {127, 373,  406,
-                                                           633, 1220, 0};
+                                                           633, 1220, 0, 0};
 __attribute__((aligned(8))) static const i8 pst_rank[] = {
     0,   -7,  -8,  -8, -1, 24, 79, 0,   // Pawn
     -20, -11, -1,  8,  16, 18, 5,  -16, // Knight
@@ -577,7 +577,7 @@ static i32 search(Position *const pos, const i32 ply, i32 depth, i32 alpha,
       const i32 order_move_score =
           *(u64 *)&best_moves[ply] == *(u64 *)&moves[order_index]
               ? 1000000
-              : piece_on(pos, moves[order_index].to) != None;
+              : material[piece_on(pos, moves[order_index].to)];
       if (order_move_score > move_score) {
         move_score = order_move_score;
 


### PR DESCRIPTION
Use material value of victim to score captures.

Score of 4k_d vs 4k_m: 635 - 507 - 1258  [0.527] 2400
...      4k_d playing White: 369 - 219 - 612  [0.563] 1200
...      4k_d playing Black: 266 - 288 - 646  [0.491] 1200
...      White vs Black: 657 - 485 - 1258  [0.536] 2400
Elo difference: 18.5 +/- 9.6, LOS: 100.0 %, DrawRatio: 52.4 %

Size: 3 844 bytes