### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,8 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: install libraries
+      run: sudo apt install libmpfr-dev libgmp3-dev libmpc-dev -y
+
     - name: configure
-      run: ./configure
+      run: ./configure -v --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --prefix=/usr/local/gcc-dev --enable-checking=release --enable-languages=c --disable-multilib --program-suffix=-dev
 
     - name: Install dependencies
       run: make


### PR DESCRIPTION
GitHub Actions provides free CI with reproducible builds on each commit, if you can get it working in the first place.